### PR TITLE
Maya/trigger reload when music ends

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,6 @@ import AudioVisualizer from "./sections/AudioVisualizer";
 
 import { myContext } from "./components/ContextProvider";
 import LoadingScreen from "./components/LoadingScreenStart";
-import LoadingScreenCharSelect from "./components/LoadingScreenCharSelect";
 import ScrollBtn from "./components/ScrollBtn";
 
 import QuackText from "./components/QuackText";
@@ -90,9 +89,6 @@ function App() {
               ""
             )}
           </div>
-          {renderS2Loading && (
-            <LoadingScreenCharSelect setRenderS2Loading={setRenderS2Loading} />
-          )}
         </main>
       )}
     </div>

--- a/src/components/LoadingScreenToSection.jsx
+++ b/src/components/LoadingScreenToSection.jsx
@@ -4,10 +4,15 @@ import { useGSAP } from "@gsap/react";
 import { ducks } from "../../data";
 import { myContext } from "./ContextProvider";
 
-export default function LoadingScreenCharSelect({ setRenderS2Loading }) {
+export default function LoadingScreenToSection({ sectionId, text }) {
 	const containerRef = useRef();
 	const title = useRef();
-	const { activeDuck } = myContext();
+	const { activeDuck, setActiveSectionNumb } = myContext();
+	const titleString = text;
+
+	setTimeout(() => {
+		setActiveSectionNumb(Number(sectionId.slice(-1)));
+	}, 1500);
 
 	useGSAP(() => {
 		gsap.from(containerRef.current, {
@@ -18,8 +23,8 @@ export default function LoadingScreenCharSelect({ setRenderS2Loading }) {
 				document.body.style.overflow = "hidden";
 			},
 			onComplete: () => {
-				const s2 = document.getElementById("s2");
-				s2.scrollIntoView({ behavior: "smooth" });
+				const section = document.getElementById(sectionId);
+				section.scrollIntoView({ behavior: "smooth" });
 
 				// Re-enable scrolling after the scrollIntoView animation has finished
 				setTimeout(() => {
@@ -32,9 +37,6 @@ export default function LoadingScreenCharSelect({ setRenderS2Loading }) {
 			duration: 2,
 			delay: 3,
 			ease: "power4.inOut",
-			onComplete: () => {
-				setRenderS2Loading(false);
-			},
 		});
 		gsap.fromTo(
 			title.current.children,
@@ -49,8 +51,6 @@ export default function LoadingScreenCharSelect({ setRenderS2Loading }) {
 		);
 	}, []);
 
-	const titleString = "CHOOSE ANOTHER DUCK";
-
 	return (
 		<div className=" h-[100vh] w-full z-[1000] fixed top-0 left-0 flex justify-center items-center" ref={containerRef} style={{ backgroundColor: ducks[activeDuck].secondaryClr }}>
 			<h1 className="m-0 text-[#FBD652] lg:text-[5rem] flex" ref={title} style={{ color: ducks[activeDuck].primaryClr }}>
@@ -58,7 +58,7 @@ export default function LoadingScreenCharSelect({ setRenderS2Loading }) {
 					.replace(/ /g, "\u00a0")
 					.split("")
 					.map((item, index) => (
-						<span className="reveal relative" key={index}>
+						<span className="reveal relative uppercase" key={index}>
 							{item}
 						</span>
 					))}

--- a/src/components/LoadingScreenToSection.jsx
+++ b/src/components/LoadingScreenToSection.jsx
@@ -7,12 +7,10 @@ import { myContext } from "./ContextProvider";
 export default function LoadingScreenToSection({ sectionId, text }) {
 	const containerRef = useRef();
 	const title = useRef();
-	const { activeDuck, setActiveSectionNumb } = myContext();
+	const { activeDuck } = myContext();
 	const titleString = text;
 
-	setTimeout(() => {
-		setActiveSectionNumb(Number(sectionId.slice(-1)));
-	}, 1500);
+
 
 	useGSAP(() => {
 		gsap.from(containerRef.current, {

--- a/src/components/Mic.jsx
+++ b/src/components/Mic.jsx
@@ -10,8 +10,8 @@ export default function MicIcon({ isOn }) {
 	return (
 		<div className=" flex items-center  relative">
 			<FaPowerOff
-				style={{ border: "solid 3px" + ducks[activeDuck].primaryClr, backgroundColor: ducks[activeDuck].primaryClr, color: ducks[activeDuck].secondaryClr }}
-				className={`${isOn ? "opacity-0" : "opacity-100" } transition-all hover:scale-110 duration-200 rounded-full text-7xl absolute left-1 bottom-12`}
+				style={{ color: ducks[activeDuck].secondaryClr }}
+				className={`${isOn ? "opacity-0" : "opacity-100" } transition-all hover:scale-110 duration-200 z-20 rounded-full text-7xl absolute left-1 bottom-12`}
 			/>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Mic.jsx
+++ b/src/components/Mic.jsx
@@ -21,7 +21,8 @@ export default function MicIcon({ isOn }) {
 				xml:space="preserve"
 				width="100%"
 				height="100%"
-				fill={ducks[activeDuck].secondaryClr}>
+				fill={ducks[activeDuck].secondaryClr}
+				className= {isOn ? "opacity-100" : "opacity-60" }>
 				<g>
 					<path d="M39.87536,66.49539V66.5H18.00849v-0.00461c0-2.44387,1.98115-4.42502,4.42501-4.42502h13.01684   C37.89421,62.07037,39.87536,64.05152,39.87536,66.49539z" />
 					<path d="M31.96408,30.68119v23.10226h-6.05061V30.75385c0.87181,0.59151,1.90965,0.9133,2.96826,0.9133   C30.00256,31.66715,31.07156,31.32465,31.96408,30.68119z" />

--- a/src/components/Mic.jsx
+++ b/src/components/Mic.jsx
@@ -15,10 +15,10 @@ export default function MicIcon({ isOn }) {
 			/>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
-				xmlns:xlink="http://www.w3.org/1999/xlink"
+				xmlnsXlink="http://www.w3.org/1999/xlink"
 				version="1.1"
 				viewBox="20 2 35 60"
-				xml:space="preserve"
+				xmlSpace="preserve"
 				width="100%"
 				height="100%"
 				fill={ducks[activeDuck].secondaryClr}

--- a/src/components/ScrollBtn.jsx
+++ b/src/components/ScrollBtn.jsx
@@ -18,9 +18,6 @@ function ScrollBtn() {
 
   const {
     hover,
-    setHover,
-    isAudioCtxActivated,
-    setIsAudioCtxActivated,
     activeDuck,
     activeSectionNumb,
     setActiveSectionNumb,

--- a/src/components/ScrollBtn.jsx
+++ b/src/components/ScrollBtn.jsx
@@ -1,116 +1,92 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from "react";
 
-import { ducks } from '../../data';
-import { myContext } from '../components/ContextProvider.jsx';
+import { ducks } from "../../data";
+import { myContext } from "../components/ContextProvider.jsx";
 
-import { TbArrowBigDownFilled } from 'react-icons/tb';
-import { TbArrowBigUpFilled } from 'react-icons/tb';
+import { TbArrowBigDownFilled } from "react-icons/tb";
+import { TbArrowBigUpFilled } from "react-icons/tb";
 
 function ScrollBtn() {
-  const [arrow, setArrow] = useState(<TbArrowBigUpFilled />);
-  const [x, setX] = useState(0);
-  const [y, setY] = useState(0);
+	const [arrow, setArrow] = useState(<TbArrowBigUpFilled />);
+	const [x, setX] = useState(0);
+	const [y, setY] = useState(0);
 
-  const iconRef = useRef(null);
+	const iconRef = useRef(null);
 
-  const iconWidth = iconRef.current?.offsetWidth;
-  const iconHeight = iconRef.current?.offsetHeight;
+	const iconWidth = iconRef.current?.offsetWidth;
+	const iconHeight = iconRef.current?.offsetHeight;
 
-  const {
-    hover,
-    activeDuck,
-    activeSectionNumb,
-    setActiveSectionNumb,
-  } = myContext();
+	const { hover, activeDuck, activeSectionNumb, setActiveSectionNumb } = myContext();
 
-  useEffect(() => {
-    const updateMouseCoordinates = (e) => {
-      let y = e.clientY;
+	useEffect(() => {
+		const updateMouseCoordinates = (e) => {
+			let y = e.clientY;
 
-      setX(e.clientX);
-      setY(e.clientY);
+			setX(e.clientX);
+			setY(e.clientY);
 
-      const windowHeight = window.innerHeight;
+			const windowHeight = window.innerHeight;
 
-      if (y > windowHeight / 2) {
-        setArrow(<TbArrowBigDownFilled />);
-      }
-      if (y < windowHeight / 2) {
-        setArrow(<TbArrowBigUpFilled />);
-      }
-    };
+			if (y > windowHeight / 2) {
+				setArrow(<TbArrowBigDownFilled />);
+			}
+			if (y < windowHeight / 2) {
+				setArrow(<TbArrowBigUpFilled />);
+			}
+		};
 
-    window.addEventListener('mousemove', updateMouseCoordinates);
+		window.addEventListener("mousemove", updateMouseCoordinates);
 
-    return () => {
-      window.removeEventListener('mousemove', updateMouseCoordinates);
-    };
-  }, []);
+		return () => {
+			window.removeEventListener("mousemove", updateMouseCoordinates);
+		};
+	}, []);
 
-  useEffect(() => {
-    // console.log('activeSectionNumb', activeSectionNumb);
+	useEffect(() => {
+		// console.log('activeSectionNumb', activeSectionNumb);
 
-    const handleClick = () => {
-      const windowHeight = window.innerHeight;
+		const handleClick = () => {
+			const windowHeight = window.innerHeight;
 
-      if (activeSectionNumb === 1) {
-        setActiveSectionNumb((prevNumber) =>
-          prevNumber < 5 ? prevNumber + 1 : prevNumber
-        );
-      } else if (activeSectionNumb === 5) {
-        setActiveSectionNumb((prevNumber) =>
-          prevNumber > 1 ? prevNumber - 1 : prevNumber
-        );
-      } else if (y > windowHeight / 2) {
-        setActiveSectionNumb((prevNumber) =>
-          prevNumber < 5 ? prevNumber + 1 : prevNumber
-        );
-      } else if (y < windowHeight / 2) {
-        setActiveSectionNumb((prevNumber) =>
-          prevNumber > 1 ? prevNumber - 1 : prevNumber
-        );
-      }
-    };
+			if (activeSectionNumb === 1) {
+				setActiveSectionNumb((prevNumber) => (prevNumber < 5 ? prevNumber + 1 : prevNumber));
+			} else if (activeSectionNumb === 5) {
+				setActiveSectionNumb((prevNumber) => (prevNumber > 1 ? prevNumber - 1 : prevNumber));
+			} else if (y > windowHeight / 2) {
+				setActiveSectionNumb((prevNumber) => (prevNumber < 5 ? prevNumber + 1 : prevNumber));
+			} else if (y < windowHeight / 2) {
+				setActiveSectionNumb((prevNumber) => (prevNumber > 1 ? prevNumber - 1 : prevNumber));
+			}
+		};
 
-    if (hover === 'not-hovered') {
-      window.addEventListener('click', handleClick);
-    }
+		if (hover === "not-hovered") {
+			window.addEventListener("click", handleClick);
+		}
 
-    return () => {
-      window.removeEventListener('click', handleClick);
-    };
-  }, [y]);
+		return () => {
+			window.removeEventListener("click", handleClick);
+		};
+	}, [y]);
 
-  useEffect(() => {
-    const section = document.getElementById('s' + activeSectionNumb);
-    if (section) {
-      section.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [activeSectionNumb]);
+	useEffect(() => {
+		const section = document.getElementById("s" + activeSectionNumb);
+		if (section) {
+			section.scrollIntoView({ behavior: "smooth" });
+		}
+	}, [activeSectionNumb]);
 
-  return (
-    <div
-      ref={iconRef}
-      className={`fixed p-[20px] z-[500] text-[6rem] curer-pointer pointer-events-none ${
-        hover === 'hovered' ? 'cursor-pointer hidden' : 'cursor-none'
-      }`}
-      style={{
-        top: `${y - iconHeight / 2}px`,
-        left: `${x - iconWidth / 2}px`,
-        color: ducks[activeDuck].secondaryClr,
-      }}
-    >
-      {activeSectionNumb === 5 ? (
-        <TbArrowBigUpFilled />
-      ) : activeSectionNumb === 1 ? (
-        <TbArrowBigDownFilled />
-      ) : hover === 'hovered' ? (
-        ''
-      ) : (
-        arrow
-      )}
-    </div>
-  );
+	return (
+		<div
+			ref={iconRef}
+			className={`fixed p-[20px] z-[500] text-[6rem] curer-pointer pointer-events-none ${hover === "hovered" ? "cursor-pointer hidden" : "cursor-none"}`}
+			style={{
+				top: `${y - iconHeight / 2}px`,
+				left: `${x - iconWidth / 2}px`,
+				color: ducks[activeDuck].secondaryClr,
+			}}>
+			{activeSectionNumb === 5 ? <TbArrowBigUpFilled /> : activeSectionNumb === 1 ? <TbArrowBigDownFilled /> : hover === "hovered" ? "" : arrow}
+		</div>
+	);
 }
 
 export default ScrollBtn;

--- a/src/components/Vizualizer.jsx
+++ b/src/components/Vizualizer.jsx
@@ -41,7 +41,7 @@ export default function Visualizer() {
 
 	// Only allow duck to respond when user is in the right section
 	useEffect(() => {
-		isDuckResponding.current = activeSectionNumb === 6 ? true : false;
+		isDuckResponding.current = activeSectionNumb === 6;
 	}, [activeSectionNumb]);
 
 	// AudioContext must be initialized after a user gesture.We now have a secret workaround that the first time

--- a/src/sections/AudioVisualizer.jsx
+++ b/src/sections/AudioVisualizer.jsx
@@ -9,7 +9,7 @@ import { ducks } from "../../data";
 import LoadingScreenToSection from "../components/LoadingScreenToSection";
 
 export default function AudioVisualizer() {
-	const { setPartyOn } = myContext();
+	const { setPartyOn, setActiveSectionNumb } = myContext();
 	const [renderLoadingYES, setRenderLoadingYES] = useState(false);
 	const [renderLoadingNO, setRenderLoadingNO] = useState(false);
 
@@ -19,7 +19,6 @@ export default function AudioVisualizer() {
 	const buttonTitleWrapperRef = useRef(null);
 	const buttonsRef = useRef(null);
 	const sectionRef = useRef(null);
-	
 
 	// Text and buttons enter
 	useGSAP(
@@ -56,18 +55,21 @@ export default function AudioVisualizer() {
 			opacity: 0,
 		});
 
-		let test = true;
+		let continueInterval = true;
 		setInterval(() => {
-			if (songRef.current.paused && test) {
+			if (songRef.current.paused && continueInterval) {
 				setRenderLoadingNO(true);
 				setTimeout(() => {
 					setPartyOn(false);
+					setActiveSectionNumb(1);
 				}, 1500);
+				continueInterval = false;
 			}
 		}, 1000);
 	}
 
 	function handleClickYes() {
+		setActiveSectionNumb(2);
 		setRenderLoadingYES(true);
 	}
 

--- a/src/sections/AudioVisualizer.jsx
+++ b/src/sections/AudioVisualizer.jsx
@@ -1,85 +1,83 @@
-import React, { useEffect, useRef, useState } from 'react';
-import P from '../components/P';
-import Visualizer from '../components/Vizualizer';
-import { myContext } from '../components/ContextProvider';
-import Button from '../components/Button';
-import { gsap } from 'gsap';
-import { useGSAP } from '@gsap/react';
-import { ducks } from '../../data';
+import React, { useEffect, useRef, useState } from "react";
+import P from "../components/P";
+import Visualizer from "../components/Vizualizer";
+import { myContext } from "../components/ContextProvider";
+import Button from "../components/Button";
+import { gsap } from "gsap";
+import { useGSAP } from "@gsap/react";
+import { ducks } from "../../data";
 
 export default function AudioVisualizer() {
-  const { setPartyOn, setRenderS2Loading, activeDuc, setActiveSectionNumb } =
-    myContext();
-  const songRef = useRef(null);
-  const textRef = useRef(null);
-  const wrapperRef = useRef(null);
-  const buttonsRef = useRef(null);
-  const sectionRef = useRef(null);
+	const { setPartyOn, setRenderS2Loading, activeDuc, setActiveSectionNumb } = myContext();
+	const songRef = useRef(null);
+	const textRef = useRef(null);
+	const wrapperRef = useRef(null);
+	const buttonsRef = useRef(null);
+	const sectionRef = useRef(null);
 
-  // Text and buttons enter
-  useGSAP(
-    () => {
-      const tl = gsap.timeline({
-        scrollTrigger: {
-          trigger: sectionRef.current,
-          start: 'top center',
-          end: 'bottom center',
-        },
-      });
-      tl.to(textRef.current, {
-        delay: 7,
-        duration: 2,
-        text: `Are you still stuck?`,
-      });
-      tl.to(buttonsRef.current.children, {
-        translateY: 0,
-        ease: 'back.out',
-        stagger: 0.1,
-        duration: 0.2,
-      });
-    },
-    { scope: sectionRef }
-  );
+	// Text and buttons enter
+	useGSAP(
+		() => {
+			const tl = gsap.timeline({
+				scrollTrigger: {
+					trigger: sectionRef.current,
+					start: "top center",
+					end: "bottom center",
+				},
+			});
+			tl.to(textRef.current, {
+				delay: 7,
+				duration: 2,
+				text: `Are you still stuck?`,
+			});
+			tl.to(buttonsRef.current.children, {
+				translateY: 0,
+				ease: "back.out",
+				stagger: 0.1,
+				duration: 0.2,
+			});
+		},
+		{ scope: sectionRef }
+	);
 
-  function handleClickNo() {
-    setPartyOn(true);
-    songRef.current.play().catch((err) => {
-      console.error('Error playing song:', err);
-    });
+	function handleClickNo() {
+		setPartyOn(true);
+		songRef.current.play().catch((err) => {
+			console.error("Error playing song:", err);
+		});
 
-    gsap.to(wrapperRef.current, {
-      opacity: 0,
-    });
-  }
-  function handleClickYes() {
-    setRenderS2Loading(true);
-    // document.body.style.overflow = 'auto';
+		gsap.to(wrapperRef.current, {
+			opacity: 0,
+		});
 
-    setTimeout(() => {
-      setActiveSectionNumb(2);
-    }, 1500);
-  }
+    setInterval(() => {
+			console.log(songRef.current.paused)
+		}, 1000);
+	}
+	function handleClickYes() {
+		setRenderS2Loading(true);
+		// document.body.style.overflow = 'auto';
 
-  return (
-    <section
-      ref={sectionRef}
-      id='s6'
-      className=' w-screen relative flex items-center justify-center h-screen'
-    >
-      <div ref={wrapperRef} className={` absolute top-4 right-6 z-[500]`}>
-        <P style={'mb-2 ml-4'}>
-          <span ref={textRef}></span>
-        </P>
-        <div
-          ref={buttonsRef}
-          className='flex gap-4 *:-translate-y-[100%] overflow-hidden'
-        >
-          <Button onClick={handleClickNo} text='no' />
-          <Button onClick={handleClickYes} text='yes' />
-        </div>
-      </div>
-      <audio ref={songRef} src='../sound-effects/Wobbly-duck.mp3'></audio>
-      <Visualizer />
-    </section>
-  );
+		setTimeout(() => {
+			setActiveSectionNumb(2);
+		}, 1500);
+	}
+
+
+
+	return (
+		<section ref={sectionRef} id="s6" className=" w-screen relative flex items-center justify-center h-screen">
+			<div ref={wrapperRef} className={` absolute top-4 right-6 z-[500]`}>
+				<P style={"mb-2 ml-4"}>
+					<span ref={textRef}></span>
+				</P>
+				<div ref={buttonsRef} className="flex gap-4 *:-translate-y-[100%] overflow-hidden">
+					<Button onClick={handleClickNo} text="no" />
+					<Button onClick={handleClickYes} text="yes" />
+				</div>
+			</div>
+			<audio id="myAudio" ref={songRef} src="../sound-effects/Wobbly-duck.mp3"></audio>
+			<Visualizer />
+		</section>
+	);
 }

--- a/src/sections/AudioVisualizer.jsx
+++ b/src/sections/AudioVisualizer.jsx
@@ -6,14 +6,20 @@ import Button from "../components/Button";
 import { gsap } from "gsap";
 import { useGSAP } from "@gsap/react";
 import { ducks } from "../../data";
+import LoadingScreenToSection from "../components/LoadingScreenToSection";
 
 export default function AudioVisualizer() {
-	const { setPartyOn, setRenderS2Loading, activeDuc, setActiveSectionNumb } = myContext();
+	const { setPartyOn } = myContext();
+	const [renderLoadingYES, setRenderLoadingYES] = useState(false);
+	const [renderLoadingNO, setRenderLoadingNO] = useState(false);
+
+	// DOM
 	const songRef = useRef(null);
 	const textRef = useRef(null);
-	const wrapperRef = useRef(null);
+	const buttonTitleWrapperRef = useRef(null);
 	const buttonsRef = useRef(null);
 	const sectionRef = useRef(null);
+	
 
 	// Text and buttons enter
 	useGSAP(
@@ -46,28 +52,28 @@ export default function AudioVisualizer() {
 			console.error("Error playing song:", err);
 		});
 
-		gsap.to(wrapperRef.current, {
+		gsap.to(buttonTitleWrapperRef.current, {
 			opacity: 0,
 		});
 
-    setInterval(() => {
-			console.log(songRef.current.paused)
+		let test = true;
+		setInterval(() => {
+			if (songRef.current.paused && test) {
+				setRenderLoadingNO(true);
+				setTimeout(() => {
+					setPartyOn(false);
+				}, 1500);
+			}
 		}, 1000);
 	}
+
 	function handleClickYes() {
-		setRenderS2Loading(true);
-		// document.body.style.overflow = 'auto';
-
-		setTimeout(() => {
-			setActiveSectionNumb(2);
-		}, 1500);
+		setRenderLoadingYES(true);
 	}
-
-
 
 	return (
 		<section ref={sectionRef} id="s6" className=" w-screen relative flex items-center justify-center h-screen">
-			<div ref={wrapperRef} className={` absolute top-4 right-6 z-[500]`}>
+			<div ref={buttonTitleWrapperRef} className={` absolute top-4 right-6 z-[500]`}>
 				<P style={"mb-2 ml-4"}>
 					<span ref={textRef}></span>
 				</P>
@@ -78,6 +84,8 @@ export default function AudioVisualizer() {
 			</div>
 			<audio id="myAudio" ref={songRef} src="../sound-effects/Wobbly-duck.mp3"></audio>
 			<Visualizer />
+			{renderLoadingYES ? <LoadingScreenToSection sectionId="s2" text="Try another duck!" /> : null}
+			{renderLoadingNO ? <LoadingScreenToSection sectionId="s1" text="Party's over" /> : null}
 		</section>
 	);
 }

--- a/src/sections/DescSectionThree.jsx
+++ b/src/sections/DescSectionThree.jsx
@@ -55,7 +55,7 @@ function DescSectionThree() {
 						onMouseLeave={() => setHover("not-hovered")}
 						ref={micRef}
 						className={` ${activeSectionNumb <= 5 ? "absolute" : "fixed"}  left-[7vw] bottom-[-50%] w-20 sm:w-40 z-[100]  `}>
-						{isMicOn ? <MicIcon isOn={true} /> : <MicIcon isOn={false} />}
+						<MicIcon isOn={isMicOn} /> 
 					</button>
 				</>
 			)}

--- a/src/sections/DescSectionThree.jsx
+++ b/src/sections/DescSectionThree.jsx
@@ -13,6 +13,12 @@ function DescSectionThree() {
 	const micRef = useRef(null);
 	const [isMicOn, setIsMicOn] = useState(false);
 
+	useEffect(() => {
+		if (activeSectionNumb < 5) {
+			setIsMicOn(false);
+		}
+	}, [activeSectionNumb]);
+
 	function handleOnClick() {
 		setIsMicOn(true);
 		setActiveSectionNumb(6);
@@ -21,9 +27,6 @@ function DescSectionThree() {
 			setIsAudioCtxActivated(true);
 		}
 	}
-	useEffect(() => {
-		console.log(hover);
-	}, [hover]);
 
 	useGSAP(() => {
 		// Generate unique class names
@@ -54,8 +57,8 @@ function DescSectionThree() {
 						onMouseEnter={() => setHover("hovered")}
 						onMouseLeave={() => setHover("not-hovered")}
 						ref={micRef}
-						className={` ${activeSectionNumb <= 5 ? "absolute" : "fixed"}  left-[7vw] bottom-[-50%] w-20 sm:w-40 z-[100]  `}>
-						<MicIcon isOn={isMicOn} /> 
+						className={` ${activeSectionNumb <= 5 ? "absolute" : "fixed"}  left-[7vw] ${isMicOn ? "bottom-0" : "bottom-[-50%] "}  w-20 sm:w-40 z-[100]  `}>
+						<MicIcon isOn={isMicOn} />
 					</button>
 				</>
 			)}


### PR DESCRIPTION
I rewrote the loader to take props and adapt accordingly, right now we have tree different loader components and three different button components. We need to refractor stuff like this and also look in to the states in context as we do it. All of us needs to be better at looking into what components and states already exists before we create new ones to make our code less messy and more readable :// The setActiveSectionNumb that i used now is not the prettiest solution but it can be there until we refractorr that state. 